### PR TITLE
Fix requirement file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 pyodbc
 pymysql
-#psycopg2  # Commented out because I could not pip install it.
 six
 sqlalchemy
-geoalchemy==0.7.3
+https://github.com/ODM2/geoalchemy/archive/v0.7.3.tar.gz
 shapely
-#matplotlib
 dateutils
 pandas
+#psycopg2  # Commented out because I could not pip install it.
+#matplotlib
 #sqlalchemy-migrate

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 with open('requirements.txt') as f:
     require = f.readlines()
-install_requires = [r.strip() for r in require]
+install_requires = [r.strip() for r in require if
+                    not r.startswith('http') and not r.startswith('#')]
 
 # Get the long description from the relevant file
 # with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:


### PR DESCRIPTION
This PR will allow people to install the requirements with `pip install -r requirements.txt` as well as installing the source dist with `pip`.

I tried this and all seems to work:

```shell
mkvirtualenv TMP --python=/usr/bin/python2
python setup.py sdist
cd dist

pip install --process-dependency-links odm2api-0.1.tar.gz
```

Note that `--process-dependency-links` seems to be deprecated:

    Dependency Links processing has been deprecated with an accelerated time schedule and
    will be removed in pip 1.6.

Not sure how to solve that.  I read a few threads that suggests this it won't be removed...

PS: Note that I am using the forked `v0.7.3` tag for `geoalchemy` on both the requirements file and on `setup.py`.  We can changed that to accept any future version, but I thought that this is "safer" for now.