### PR TITLE
Remove geoalchemy dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 pyodbc
 six
-sqlalchemy
-#-e git+https://github.com/ODM2/geoalchemy.git@v0.7.4#egg=geoalchemy-0.7.4
 #shapely
 pandas
 #psycopg2  # Commented out because I could not pip install it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyodbc
 six
-#shapely
+sqlalchemy
 pandas
 #psycopg2  # Commented out because I could not pip install it.

--- a/setup.py
+++ b/setup.py
@@ -92,14 +92,9 @@ setup(
     #     'pyodbc',
     #     'six',
     #     'sqlalchemy',
-    #     'geoalchemy>=0.7.3',
     #     'shapely',
     #     'pandas',
     # ],
-    # dependency_links- geoalchemy from the ODM repository
-    dependency_links=[
-        "git+https://github.com/ODM2/geoalchemy.git@v0.7.4#egg=geoalchemy-0.7.4"
-    ],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
This PR partially addresses https://github.com/ODM2/ODM2PythonAPI/issues/59#issuecomment-286564392

Note that PR https://github.com/ODM2/ODM2PythonAPI/pull/58 (mentioned in https://github.com/ODM2/ODM2PythonAPI/issues/59) was merged but https://github.com/geoalchemy/geoalchemy/pull/42 was not. It seems that if the path is to remove `geoalchemy` https://github.com/geoalchemy/geoalchemy/pull/42 will need to be re-written or just closed.

I could not find any other code reference to `geoalchemy` in master. I am unsure of the status on the multiple branches. BTW that many branches put a really high bar to get third party contributions to the code. I would be nice to reduce the development to `master` and eliminate the branches to temporary work on active PRs or stable releases.

I could not get the CIs to pass but looking at the history it seems that it is not passing for sometime now.

cc @emiliom and @valentinedwv 

xref #59 