### PR TITLE
Add Travis-CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ODM2 Python API
-====
+===============
+
+[![Build Status](https://travis-ci.org/ODM2/ODM2PythonAPI.svg?branch=master)](https://travis-ci.org/ODM2/ODM2PythonAPI)
 
 A Python-based application programmer's interface for the [Observations Data Model 2 (ODM2)](http://odm2.org).
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ ODM2 Python API
 
 [![Build Status](https://travis-ci.org/ODM2/ODM2PythonAPI.svg?branch=master)](https://travis-ci.org/ODM2/ODM2PythonAPI)
 
+[![Build status](https://ci.appveyor.com/api/projects/status/47pry4brcrlls6hd/branch/master?svg=true)](https://ci.appveyor.com/project/sreeder/odm2pythonapi/branch/master)
+
+
 A Python-based application programmer's interface for the [Observations Data Model 2 (ODM2)](http://odm2.org).
 
 [List of current and planned functions included in the API](https://github.com/ODM2/ODM2PythonAPI/blob/master/doc/APIFunctionList.md)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ ODM2 Python API
 ===============
 
 [![Build Status](https://travis-ci.org/ODM2/ODM2PythonAPI.svg?branch=master)](https://travis-ci.org/ODM2/ODM2PythonAPI)
-
 [![Build status](https://ci.appveyor.com/api/projects/status/47pry4brcrlls6hd/branch/master?svg=true)](https://ci.appveyor.com/project/sreeder/odm2pythonapi/branch/master)
 
 


### PR DESCRIPTION
This PR only adds the Travis-CI badge in the GitHub front page (README.md).
It should help us to keep track of the tests.

@sreeder it seems that AppVeyor is running on your account. Can you get the badge URL for us? I can add it in this PR too.

- go to  https://ci.appveyor.com/project/sreeder/odm2pythonapi `setting`
- `Badges`
- copy-and-paste the `Sample markdown code`
