### PR TITLE
Try to get Travis-CI back online

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 addons:
   apt:
     packages:
-      # FIXME: When activating the services above I don't think these are needed.
+      # FIXME: when activating the services above I don't think these are needed.
       - odbcinst1debian2
       - odbcinst
       - tdsodbc
@@ -32,14 +32,22 @@ matrix:
   include:
   - python: 2.7
     env: TEST_TARGET=default
+  - python: 3.4
+    env: TEST_TARGET=default
   - python: 3.5
+    env: TEST_TARGET=default
+  - python: 3.6
     env: TEST_TARGET=default
   - python: 2.7
     env: TEST_TARGET=coding_standards
   allow_failures:
   - python: 2.7
     env: TEST_TARGET=coding_standards
+  - python: 3.4
+    env: TEST_TARGET=default
   - python: 3.5
+    env: TEST_TARGET=default
+  - python: 3.6
     env: TEST_TARGET=default
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,67 +1,69 @@
-git blanguage: python
-sudo: required
-# if the https://travis-ci.org/ODM2/ODM2PythonAPI/requests ever says: missing config
-# validate at: http://lint.travis-ci.org/
-python:
-#  - "2.6"
-  - "2.7"
-#  - "3.2"
-#  - "3.3"
-#  - "3.4"
-#  - "3.5"
-#  - "3.5-dev" # 3.5 development branch
-#  - "nightly" # currently points to 3.6-dev
-# command to install dependencies
-cache:
-  directories:
-    - $HOME/.cache/pip/wheels
-    - $HOME/virtualenv/python2.7.9
+language: python
+
+sudo: false
+
 services:
   - mysql
   - postgresql
+
 addons:
   apt:
     packages:
-      - cmake
-      - unixodbc
-      - unixodbc-dev
+      # FIXME: When activating the services above I don't think these are needed.
       - odbcinst1debian2
       - odbcinst
+      - tdsodbc
+      - e2fsprogs
+      # FIXME: the dependencies below can probably be replaced by conda.
+      - libc6
       - freetds-dev
       - freetds-bin
-      - tdsodbc
-      - libc6
-      - e2fsprogs
+      - unixodbc
+      - unixodbc-dev
       - mysql-client
+      # FIXME: I don't see the need for these anywhere.
+      - cmake
       - libproj-dev
       - libgeos-dev
       - libspatialite-dev
-#  mariadb: '10.1'
+
+matrix:
+  fast_finish: true
+  include:
+  - python: 2.7
+    env: TEST_TARGET=default
+  - python: 3.5
+    env: TEST_TARGET=default
+  - python: 2.7
+    env: TEST_TARGET=coding_standards
+  allow_failures:
+  - python: 2.7
+    env: TEST_TARGET=coding_standards
+  - python: 3.5
+    env: TEST_TARGET=default
+
 before_script:
   - ./ci-helpers/mysql_setup.sh
   - ./ci-helpers/postgres_setup.sh
   - ./ci-helpers/travis/freetds.sh
 
-
 before_install:
-# python -m pip makes the install go into the virtualenv
-  - sudo pip install --upgrade pip
-  - sudo python -m pip install pandas
-  - export PYMSSQL_BUILD_WITH_BUNDLED_FREETDS=1;sudo python -m  pip install pymssql
-#  - python -m  pip install mysql-python
-install: # now just our code
-  - sudo pip  install -e git+https://github.com/ODM2/geoalchemy.git@v0.7.4#egg=geoalchemy-0.7.4
-  - python -m pip install   .
-  - python -m pip install  -r requirements_tests.txt  --allow-external pyodbc --allow-unverified pyodbc
-    # pysqlite
-#  - pip install pysqlite
-  - pip list
+    - wget http://bit.ly/miniconda -O miniconda.sh
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - conda update --yes --all
+    - conda config --add channels conda-forge --force
+    - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
+    - source activate TEST
 
-# don't forget to open up the azure mssql server to these addreses
-# https://docs.travis-ci.com/user/ip-addresses/
+# Test source distribution.
+install:
+    - python setup.py sdist && version=$(python setup.py --version) && pushd dist  && pip install odm2api-${version}.tar.gz && popd
 
-# command to run tests
 script:
-
-  - py.test
-
+  - if [[ $TEST_TARGET == 'default' ]]; then
+      py.test -vv ;
+    fi
+  - if [[ $TEST_TARGET == 'coding_standards' ]]; then
+      find . -type f -name "*.py" ! -name 'conf.py' | xargs flake8 --max-line-length=100 ;
+    fi

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
--r requirements.txt
 pytest
 pytest-cov
 mock
@@ -10,6 +9,3 @@ pymssql
 psycopg2
 #pyspatialite
 #mysql-python
-
-
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,5 @@ pymssql
 psycopg2
 #pyspatialite
 #mysql-python
+pymssql
+psycopg2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ psycopg2
 #mysql-python
 pymssql
 psycopg2
+flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
 pyodbc
-six
 sqlalchemy
-#-e git+https://github.com/ODM2/geoalchemy.git@v0.7.4#egg=geoalchemy-0.7.4
-#shapely
 pandas
-#psycopg2  # Commented out because I could not pip install it.

--- a/setup.py
+++ b/setup.py
@@ -88,19 +88,6 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
 
     install_requires=install_reqs,
-    # install_requires=[
-    #     'pyodbc',
-    #     'six',
-    #     'sqlalchemy',
-    #     'geoalchemy>=0.7.3',
-    #     'shapely',
-    #     'pandas',
-    # ],
-    # dependency_links- geoalchemy from the ODM repository
-    dependency_links=[
-        "git+https://github.com/ODM2/geoalchemy.git@v0.7.4#egg=geoalchemy-0.7.4"
-    ],
-
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
     # for example:


### PR DESCRIPTION
Similar to https://github.com/ODM2/WOFpy/pull/65 this should be reviewed, and hopefully tested, by someone with experience `ODM2PythonAPI` internals.

Currently Travis-CI is not running due to many errors that happens before the tests section. In this PR I tried to clean the configuration and the dependencies definition, which happened in multiple places, to get Travi-CI working again.

I could get to the test phase but now we have to deal with some, I beileve, genuine failures:

```
13 failed, 42 passed, 109 skipped, 1 pytest-warnings, 10 error in 7.71 seconds 
```

I also added a section for Pythons 3.4, 3.5, 3.6 and coding standards, but I marked them as expected failures because a huge effort is needed to bring those up to speed.

PS: I will take a look as AppVeyor testing in another PR.