### PR TITLE
fix getprocessinglevels to use id filter

### DIFF
--- a/odm2api/ODM2/services/readService.py
+++ b/odm2api/ODM2/services/readService.py
@@ -256,7 +256,7 @@ class ReadODM2(serviceBase):
         * Pass a list of ProcessingLevelCode - returns a single processingLevel object
         """
         q = self._session.query(ProcessingLevels)
-        if ids: q = q.filter(ProcessingLevels.ProcessingLevels.in_(ids))
+        if ids: q = q.filter(ProcessingLevels.ProcessingLevelsID.in_(ids))
         if codes: q = q.filter(ProcessingLevels.ProcessingLevelCode.in_(codes))
 
         try:


### PR DESCRIPTION
Without this, I am getting error when querying Processing Levels using ids.

```python
>>> read.getProcessingLevels(ids=[1,2])
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-41-789bf4c34817> in <module>()
----> 1 read.getProcessingLevels(ids=[1,2])

/root/miniconda/envs/iTEST/lib/python2.7/site-packages/odm2api/ODM2/services/readService.pyc in getProcessingLevels(self, ids, codes)
    257         """
    258         q = self._session.query(ProcessingLevels)
--> 259         if ids: q = q.filter(ProcessingLevels.ProcessingLevels.in_(ids))
    260         if codes: q = q.filter(ProcessingLevels.ProcessingLevelCode.in_(codes))
    261 

AttributeError: type object 'ProcessingLevels' has no attribute 'ProcessingLevels'
```