### PR TITLE
PEP 440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.5.3',
+    version='0.5.3.a0',
 
     description='A Python-based application programmers interface for the Observations Data converter 2 (ODM2) ',
     long_description=long_description,


### PR DESCRIPTION
Closes #79 

I already uploaded the package to PyPI: https://pypi.python.org/pypi/odm2api/0.5.3.a0
but we need this merged to ensure that PyPI accepts the proper version number. BTW, we don't really the alpha status IMO. The `0.x` + PyPI classifiers is enough.