### PR TITLE
Assert on any nulls

### DIFF
--- a/tests/test_odm2/test_readservice.py
+++ b/tests/test_odm2/test_readservice.py
@@ -186,10 +186,7 @@ class TestReadService:
 
         # test invalid argument
         resapi = self.reader.getRelatedModels(code = 234123)
-        assert resapi == []
-        # MySQL is very relaxed about this,
-        # should be `resapi is None` if PostgreSQL,
-        # because code type is not string
+        assert not resapi
 
 
 


### PR DESCRIPTION
## Overview

This is a patch for assertion on `resapi`. A syntax sugar as discussed [here](https://github.com/ODM2/ODM2PythonAPI/pull/92#discussion_r133334453)