### PR TITLE
Improve getAffiliation docstring to follow numpy/scipy documentation

### DIFF
--- a/odm2api/ODM2/services/readService.py
+++ b/odm2api/ODM2/services/readService.py
@@ -544,12 +544,30 @@ class ReadODM2(serviceBase):
 
     def getAffiliations(self, ids=None, personfirst=None, personlast=None, orgcode=None):
         """
-        getAffiliations(self, ids=None, personfirst=None, personlast=None, orgcode=None)
-        * Pass nothing - returns a list of all Affiliation objects
-        * Pass a list of AffiliationID - returns a single Affiliation object
-        * Pass a First Name - returns a single Affiliation object
-        * Pass a Last Name - returns a single Affiliation object
-        * Pass an OrganizationCode - returns a Affiliation object
+        Retrieve a list of ODM2 Affiliation objects.
+
+        Parameters
+        ----------
+        ids: list, default None
+            List of AffiliationIDs
+        personfirst: str, default None
+            Person First Name
+        personlast: str, default None
+            Person Last Name
+        orgcode: str, default None
+            Organization Code
+
+        Returns
+        -------
+        List of Affiliation objects
+
+        Examples
+        --------
+        >>> read.getAffiliations(ids=[39,40])
+        >>> read.getAffiliations(personfirst='Anthony',
+        ...                      personlast='Aufdenkampe')
+        >>> read.getAffiliations(orgcode='LimnoTech')
+
         """
         q = self._session.query(Affiliations)
 

--- a/odm2api/ODM2/services/readService.py
+++ b/odm2api/ODM2/services/readService.py
@@ -543,30 +543,25 @@ class ReadODM2(serviceBase):
             return None
 
     def getAffiliations(self, ids=None, personfirst=None, personlast=None, orgcode=None):
-        """
-        Retrieve a list of ODM2 Affiliation objects.
+        """Retrieve a list of Affiliation objects.
 
-        Parameters
-        ----------
-        ids: list, default None
-            List of AffiliationIDs
-        personfirst: str, default None
-            Person First Name
-        personlast: str, default None
-            Person Last Name
-        orgcode: str, default None
-            Organization Code
+        If no arguments are passed to the function, or their values are None,
+        all Affiliation objects in the database will be returned.
 
-        Returns
-        -------
-        List of Affiliation objects
+        Args:
+            ids (:obj:`list`, optional): List of AffiliationIDs. Defaults to None.
+            personfirst (:obj:`str`, optional): Person First Name. Defaults to None.
+            personlast (:obj:`str`, optional): Person Last Name. Defaults to None.
+            orgcode (:obj:`str`, optional): Organization Code. Defaults to None.
 
-        Examples
-        --------
-        >>> read.getAffiliations(ids=[39,40])
-        >>> read.getAffiliations(personfirst='Anthony',
-        ...                      personlast='Aufdenkampe')
-        >>> read.getAffiliations(orgcode='LimnoTech')
+        Returns:
+            list: List of Affiliation objects
+
+        Examples:
+            >>> read.getAffiliations(ids=[39,40])
+            >>> read.getAffiliations(personfirst='John',
+            ...                      personlast='Smith')
+            >>> read.getAffiliations(orgcode='Acme')
 
         """
         q = self._session.query(Affiliations)


### PR DESCRIPTION
## Overview

This PR improves the docstring for `getAffiliations` to follow the numpy/scipy documentation standard. If you have suggestions of better wordings, please let me know. This relates to #97.