### PR TITLE
Error in DataLoggerFiles and DataLoggerFileColumns #132

### DIFF
--- a/odm2api/ODM2/models.py
+++ b/odm2api/ODM2/models.py
@@ -457,10 +457,10 @@ class DataLoggerProgramFiles(Base):
 class DataLoggerFiles(Base):
 
     DataLoggerFileID = Column('dataloggerfileid', Integer, primary_key=True, nullable=False)
-    ProgramID = Column('actionid', Integer, ForeignKey(DataLoggerProgramFiles.ProgramID), nullable=False)
+    ProgramID = Column('programid', Integer, ForeignKey(DataLoggerProgramFiles.ProgramID), nullable=False)
     DataLoggerFileName = Column('dataloggerfilename', String(255), nullable=False)
-    DataLoggerOutputFileDescription = Column('dataloggeroutputfiledescription', String(500))
-    DataLoggerOutputFileLink = Column('dataloggeroutputfilelink', String(255))
+    DataLoggerOutputFileDescription = Column('dataloggerfiledescription', String(500))
+    DataLoggerOutputFileLink = Column('dataloggerfilelink', String(255))
 
     ProgramObj = relationship(DataLoggerProgramFiles)
 
@@ -513,7 +513,7 @@ class DataLoggerFileColumns(Base):
                                         nullable=False)
     ColumnLabel = Column('columnlabel', String(50), nullable=False)
     ColumnDescription = Column('columndescription', String(500))
-    MeasurementEquation = Column('measurmentequation', String(255))
+    MeasurementEquation = Column('measurementequation', String(255))
     ScanInterval = Column('scaninterval', Float(50))
     ScanIntervalUnitsID = Column('scanintervalunitsid', Integer, ForeignKey(Units.UnitsID))
     RecordingInterval = Column('recordinginterval', Float(50))


### PR DESCRIPTION
## Overview

This is the same exact changes by @miguelcleon on PR #133. Just cleaner without the `.travis.yml` changes.

## Notes
From @miguelcleon:
see that the first one, this is caused by Dataloggerfiles model, mapping to the wrong column within the database: https://github.com/ODM2/ODM2PythonAPI/blob/master/odm2api/ODM2/models.py#L458.

For the second one, measurementequation is indeed misspelled: https://github.com/ODM2/ODM2PythonAPI/blob/master/odm2api/ODM2/models.py#L514.

also 

found two more problems with dataloggerfiles model 
There is no column `dataloggeroutputfiledescription` instead it is `dataloggerfiledescription`
https://github.com/ODM2/ODM2PythonAPI/blob/master/odm2api/ODM2/models.py#L460

There is no column `dataloggeroutputfilelink` instead it is `dataloggerfilelink`
https://github.com/ODM2/ODM2PythonAPI/blob/master/odm2api/ODM2/models.py#L461