### PR TITLE
Allow sfid to be None to work with older code

### DIFF
--- a/odm2api/ODM2/services/readService.py
+++ b/odm2api/ODM2/services/readService.py
@@ -801,7 +801,8 @@ class ReadODM2(serviceBase):
             warnings.warn('The parameter \'sfid\' is deprecated. '
                           'Please use the sfids parameter instead and send in a list.',
                           DeprecationWarning, stacklevel=2)
-            query = query.join(FeatureActions).filter_by(SamplingFeatureID=kwargs['sfid'])
+            if kwargs['sfid']:
+                query = query.join(FeatureActions).filter_by(SamplingFeatureID=kwargs['sfid'])
         if sfids or sfcodes or sfuuids:
             sf_list = self.getSamplingFeatures(ids=sfids, codes=sfcodes, uuids=sfuuids)
             sfids = []


### PR DESCRIPTION
## Overview

While working on the `odm2restapi`, I noticed that `getResults` was returning nothing when `sfid` is `None`, so this should fix that and `getResults` should return all results when `sfid` is `None`.