### PR TITLE
Make lowercase columns default, add option to make them same as model

### DIFF
--- a/odm2api/ODM2/services/readService.py
+++ b/odm2api/ODM2/services/readService.py
@@ -935,6 +935,10 @@ class ReadODM2(serviceBase):
                 `controlled vocabulary name <http://vocabulary.odm2.org/datasettype/>`_.
             lowercols (bool, optional): Make column names to be lowercase.
                                         Default to True.
+                                        **Please start upgrading your code to rely on CamelCase column names,
+                                        In a near-future release,
+                                        the default will be changed to False,
+                                        and later the parameter may be removed**.
 
 
         Returns:

--- a/odm2api/ODM2/services/readService.py
+++ b/odm2api/ODM2/services/readService.py
@@ -1349,6 +1349,10 @@ class ReadODM2(serviceBase):
             endtime (object, optional): End time to filter by as datetime object.
             lowercols (bool, optional): Make column names to be lowercase.
                                         Default to True.
+                                        **Please start upgrading your code to rely on CamelCase column names,
+                                        In a near-future release,
+                                        the default will be changed to False,
+                                        and later the parameter may be removed**.
 
         Returns:
             DataFrame: Pandas dataframe of result values.
@@ -1399,6 +1403,12 @@ class ReadODM2(serviceBase):
             )
             if not lowercols:
                 df.columns = [self._get_columns(ResultValues)[c] for c in df.columns]
+            else:
+                warnings.warn(
+                    'In a near-future release, '
+                    'the parameter \'lowercols\' default will be changed to False, '
+                    'and later the parameter may be removed.',
+                    DeprecationWarning, stacklevel=2)
             return df
         except Exception as e:
             print('Error running Query: {}'.format(e))

--- a/odm2api/ODM2/services/readService.py
+++ b/odm2api/ODM2/services/readService.py
@@ -923,7 +923,7 @@ class ReadODM2(serviceBase):
             print('Error running Query {}'.format(e))
         return None
 
-    def getDataSetsValues(self, ids=None, codes=None, uuids=None, dstype=None):
+    def getDataSetsValues(self, ids=None, codes=None, uuids=None, dstype=None, lowercols=True):
         """
         Retrieve a list of datavalues associated with the given dataset info
 
@@ -934,6 +934,8 @@ class ReadODM2(serviceBase):
             uuids (list, optional): List of Dataset UUIDs string.
             dstype (str, optional): Type of Dataset from
                 `controlled vocabulary name <http://vocabulary.odm2.org/datasettype/>`_.
+            lowercols (bool, optional): Make column names to be lowercase.
+                                        Default to True.
 
 
         Returns:
@@ -945,7 +947,7 @@ class ReadODM2(serviceBase):
             >>> READ.getDataSetsValues(codes=['HOME', 'FIELD'])
             >>> READ.getDataSetsValues(uuids=['a6f114f1-5416-4606-ae10-23be32dbc202',
             ...                                 '5396fdf3-ceb3-46b6-aaf9-454a37278bb4'])
-            >>> READ.getDataSetsValues(dstype='singleTimeSeries')
+            >>> READ.getDataSetsValues(dstype='singleTimeSeries', lowercols=False)
 
         """
 
@@ -956,7 +958,7 @@ class ReadODM2(serviceBase):
             resids.append(ds.ResultID)
 
         try:
-            return self.getResultValues(resultids = resids)
+            return self.getResultValues(resultids=resids, lowercols=lowercols)
         except Exception as e:
             print('Error running Query {}'.format(e))
         return None
@@ -1336,7 +1338,7 @@ class ReadODM2(serviceBase):
         """
         return self._session.query(ResultDerivationEquations).all()
 
-    def getResultValues(self, resultids, starttime=None, endtime=None):
+    def getResultValues(self, resultids, starttime=None, endtime=None, lowercols=True):
         """
         Retrieve result values associated with the given result.
 
@@ -1345,6 +1347,8 @@ class ReadODM2(serviceBase):
             resultids (list): List of SamplingFeatureIDs.
             starttime (object, optional): Start time to filter by as datetime object.
             endtime (object, optional): End time to filter by as datetime object.
+            lowercols (bool, optional): Make column names to be lowercase.
+                                        Default to True.
 
         Returns:
             DataFrame: Pandas dataframe of result values.
@@ -1355,7 +1359,7 @@ class ReadODM2(serviceBase):
             >>> READ.getResultValues(resultids=[100, 20, 34], starttime=datetime.today())
             >>> READ.getResultValues(resultids=[1, 2, 3, 4],
             >>>     starttime=datetime(2000, 01, 01),
-            >>>     endtime=datetime(2003, 02, 01))
+            >>>     endtime=datetime(2003, 02, 01), lowercols=False)
 
         """
         restype = self._session.query(Results).filter_by(ResultID=resultids[0]).first().ResultTypeCV
@@ -1393,7 +1397,8 @@ class ReadODM2(serviceBase):
                 con=self._session_factory.engine,
                 params=query.params
             )
-            df.columns = [self._get_columns(ResultValues)[c] for c in df.columns]
+            if not lowercols:
+                df.columns = [self._get_columns(ResultValues)[c] for c in df.columns]
             return df
         except Exception as e:
             print('Error running Query: {}'.format(e))


### PR DESCRIPTION
## Overview

This PR Addresses https://github.com/ODM2/ODM2PythonAPI/issues/127#issuecomment-356519409. Now `getResultValues` and `getDatasetsValues` have an additional argument called `lowercols`, which defaults to `True` to keep the api the same, and make changes less disruptive. I have tested this and it works.

I was wondering if I should create some sort of warning here too saying how this argument will be deprecated in the next release after this one, and the `*values` dataframe will default to columns similar to the model in future releases, therefore user have to add `lowercase=False` to anticipate for that?