### PR TITLE
Updated odm2api module path calls in tests/test_odm2 modules to remove deprecated use of ODM2 module hierarchy

### DIFF
--- a/tests/test_SessionFactory.py
+++ b/tests/test_SessionFactory.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
-from odm2api.ODM2.models import CVElevationDatum, setSchema
+from odm2api.models import CVElevationDatum, setSchema
 from odm2api.ODMconnection import SessionFactory
 
 import pytest

--- a/tests/test_SessionFactory.py
+++ b/tests/test_SessionFactory.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
-from odm2api.models import CVElevationDatum, setSchema
 from odm2api.ODMconnection import SessionFactory
+from odm2api.models import CVElevationDatum, setSchema
 
 import pytest
 
@@ -15,10 +15,10 @@ dbs_readonly = [
     ['mysql"root@Localhost/odm2', 'mysql', 'mysql+pymysql://root@localhost/odm2'],
     ['postgresql_marchantariats_none', 'postgresql',
      'postgresql+psycopg2://postgres:None@localhost/marchantariats',
-     'marchantariats', 'postgres',  None],
+     'marchantariats', 'postgres', None],
     ['postgresql_marchantariats_empty', 'postgresql',
      'postgresql+psycopg2://postgres@localhost/marchantariats',
-     'marchantariats', 'postgres',  None],
+     'marchantariats', 'postgres', None],
     ['sqlite_wof', 'sqlite', 'sqlite:///./tests/spatialite/wof2odm/ODM2.sqlite', None, None, None]
 ]
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
-from odm2api.models import CVElevationDatum
 from odm2api.ODMconnection import dbconnection
+from odm2api.models import CVElevationDatum
 
 import pytest
 
@@ -13,7 +13,7 @@ __author__ = 'valentine'
 dbs_readonly = [
     ['mysql_odm2_odm', 'mysql', 'localhost', 'odm2', 'ODM', 'odm'],
     ['mysql_odm2_root', 'mysql', 'localhost', 'odm2', 'root', None],
-    ['postgresql_marchantariats', 'postgresql', 'localhost', 'marchantariats', 'postgres',  'iforget'],
+    ['postgresql_marchantariats', 'postgresql', 'localhost', 'marchantariats', 'postgres', 'iforget'],
     ['sqlite_wof', 'sqlite', './tests/spatialite/wof2odm/ODM2.sqlite', None, None, None]
 ]
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
-from odm2api.ODM2.models import CVElevationDatum
+from odm2api.models import CVElevationDatum
 from odm2api.ODMconnection import dbconnection
 
 import pytest

--- a/tests/test_odm2/test_createservice.py
+++ b/tests/test_odm2/test_createservice.py
@@ -5,8 +5,8 @@ import uuid
 from os.path import abspath, dirname, join
 
 from odm2api import models
-from odm2api.services.createService import CreateODM2
 from odm2api.ODMconnection import dbconnection
+from odm2api.services.createService import CreateODM2
 
 import pytest
 # run this test from the root directory using:

--- a/tests/test_odm2/test_createservice.py
+++ b/tests/test_odm2/test_createservice.py
@@ -4,8 +4,8 @@ import datetime
 import uuid
 from os.path import abspath, dirname, join
 
-from odm2api.ODM2 import models
-from odm2api.ODM2.services.createService import CreateODM2
+from odm2api import models
+from odm2api.services.createService import CreateODM2
 from odm2api.ODMconnection import dbconnection
 
 import pytest

--- a/tests/test_odm2/test_model.py
+++ b/tests/test_odm2/test_model.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
-from odm2api.ODM2.models import (CVElevationDatum, CVSamplingFeatureGeoType,
-                                 CVSamplingFeatureType, SamplingFeatures)
+from odm2api.models import (CVElevationDatum, CVSamplingFeatureGeoType,
+                            CVSamplingFeatureType, SamplingFeatures)
 
 import pytest
 

--- a/tests/test_odm2/test_odm2.py
+++ b/tests/test_odm2/test_odm2.py
@@ -1,11 +1,12 @@
 from __future__ import (absolute_import, division, print_function)
 
-from odm2api.models import Methods, Models, People, ProcessingLevels, RelatedModels, Variables
+from odm2api.ODMconnection import dbconnection
+from odm2api.models import (Methods, Models, People,
+                            ProcessingLevels, RelatedModels, Variables)
 from odm2api.services.createService import CreateODM2
 from odm2api.services.deleteService import DeleteODM2
 from odm2api.services.readService import ReadODM2
 from odm2api.services.updateService import UpdateODM2
-from odm2api.ODMconnection import dbconnection
 
 import pytest
 

--- a/tests/test_odm2/test_odm2.py
+++ b/tests/test_odm2/test_odm2.py
@@ -1,10 +1,10 @@
 from __future__ import (absolute_import, division, print_function)
 
-from odm2api.ODM2.models import Methods, Models, People, ProcessingLevels, RelatedModels, Variables
-from odm2api.ODM2.services.createService import CreateODM2
-from odm2api.ODM2.services.deleteService import DeleteODM2
-from odm2api.ODM2.services.readService import ReadODM2
-from odm2api.ODM2.services.updateService import UpdateODM2
+from odm2api.models import Methods, Models, People, ProcessingLevels, RelatedModels, Variables
+from odm2api.services.createService import CreateODM2
+from odm2api.services.deleteService import DeleteODM2
+from odm2api.services.readService import ReadODM2
+from odm2api.services.updateService import UpdateODM2
 from odm2api.ODMconnection import dbconnection
 
 import pytest


### PR DESCRIPTION
Updated all cases of the use of deprecated ODM2 module hierarchy reported in the TravisCI log